### PR TITLE
Use globally installed ginkgo when available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,14 @@ install:
 	go install -v
 
 test:
-	GO111MODULE=off go get github.com/onsi/ginkgo/ginkgo
+	${MAKE} check_ginkgo || ${MAKE} install_ginkgo
 	GO111MODULE=on ginkgo -mod vendor -r -keepGoing -p -trace -randomizeAllSpecs -progress --race
+
+check_ginkgo:
+	ginkgo version
+
+install_ginkgo:
+	GO111MODULE=off go get github.com/onsi/ginkgo/ginkgo
 
 fmt:
 	go fmt ./...


### PR DESCRIPTION
Latest versions of ginkgo require a newer version of golang.
Also, installing a specific version of ginkgo is not easy without using
go module system and it doesn't play well with vendored packages anyway.

Since this script is mainly designed to run on CI with cfpersi/smb-unit-tests
image which contains a globally installed version of Ginkgo try to use it instead:
This change goes hand in hand with PR cloudfoundry/smb-volume-release#18

But if for whatever reason ginkgo cli couldn't be found fallback to preexisting logic
and try to install latest version of ginkgo with go get