### PR TITLE
Allow `noserverino` option to be passed as param

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,5 +1,5 @@
 package main
 
 func AllowedOptions() string {
-	return "source,mount,ro,username,password,domain,version,mfsymlinks"
+	return "source,mount,ro,username,password,domain,version,mfsymlinks,noserverino"
 }

--- a/config.go
+++ b/config.go
@@ -1,5 +1,5 @@
 package main
 
 func AllowedOptions() string {
-	return "source,mount,ro,username,password,domain,version,mfsymlinks,noserverino"
+	return "source,mount,ro,username,password,domain,version,mfsymlinks,noserverino,forceuid,noforceuid,forcegid,noforcegid"
 }

--- a/config_test.go
+++ b/config_test.go
@@ -9,7 +9,7 @@ import (
 var _ = Describe("Config", func() {
 
 	It("should return the correct allowed options", func() {
-		Expect(AllowedOptions()).To(Equal("source,mount,ro,username,password,domain,version,mfsymlinks"))
+		Expect(AllowedOptions()).To(Equal("source,mount,ro,username,password,domain,version,mfsymlinks,noserverino,forceuid,noforceuid,forcegid,noforcegid"))
 	})
 
 })


### PR DESCRIPTION
- This is to address an issue where files cannot be access on Jammy