### PR TITLE
fix e6ddc7d908548c75a71e054e6ef5dc8feffe61f3

### DIFF
--- a/main.go
+++ b/main.go
@@ -166,7 +166,7 @@ func parseEnvironment() {
 	}
 	uaaClientIDString, _ := os.LookupEnv("UAA_CLIENT_ID")
 	if uaaClientIDString != "" {
-		uaaClientSecret = &uaaClientIDString
+		uaaClientID = &uaaClientIDString
 	}
 }
 


### PR DESCRIPTION
this commit did a bad attempt at copy pasting. The right variable to fill with uaaClientIDString is uaaClientID and not uaaClientSecret.