### PR TITLE
Allow SMB mounts with the nodfs option

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,5 +1,5 @@
 package main
 
 func AllowedOptions() string {
-	return "source,mount,ro,username,password,domain,version,mfsymlinks,noserverino,forceuid,noforceuid,forcegid,noforcegid"
+	return "source,mount,ro,username,password,domain,version,mfsymlinks,noserverino,forceuid,noforceuid,forcegid,noforcegid,nodfs"
 }

--- a/config_test.go
+++ b/config_test.go
@@ -8,6 +8,6 @@ import (
 
 var _ = Describe("Config", func() {
 	It("should return the correct allowed options", func() {
-		Expect(AllowedOptions()).To(Equal("source,mount,ro,username,password,domain,version,mfsymlinks,noserverino,forceuid,noforceuid,forcegid,noforcegid"))
+		Expect(AllowedOptions()).To(Equal("source,mount,ro,username,password,domain,version,mfsymlinks,noserverino,forceuid,noforceuid,forcegid,noforcegid,nodfs"))
 	})
 })


### PR DESCRIPTION
A recent update to the jammy kernel seems to break smb mounts that would normally use DFS. This option is being added as a workaround for affected environments while the kernel fix is underway.

See also https://github.com/cloudfoundry/smbdriver/pull/249

[#187197643]